### PR TITLE
expose aes_decrypt for use elsewhere

### DIFF
--- a/include/fc/crypto/aes.hpp
+++ b/include/fc/crypto/aes.hpp
@@ -39,6 +39,8 @@ namespace fc {
 
     int aes_encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key,
                     unsigned char *iv, unsigned char *ciphertext);
+    int aes_decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *key,
+                    unsigned char *iv, unsigned char *plaintext);
 
     std::vector<char> aes_encrypt( const fc::sha512& key, const std::vector<char>& plain_text  );
     std::vector<char> aes_decrypt( const fc::sha512& key, const std::vector<char>& cipher_text );


### PR DESCRIPTION
I am looking at implementing the bitcoin wallet key importer in BitShares and the aes_decrypt() routine is needed for that.
