### PR TITLE
Fix multi find_package change ${Boost_LIBRARIE}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,9 @@ IF( WIN32 )
   FIND_PACKAGE(Boost 1.53 REQUIRED COMPONENTS thread date_time system filesystem program_options signals serialization chrono unit_test_framework context)
   # For Boost 1.53 on windows, coroutine was not in BOOST_LIBRARYDIR and do not need it to build,  but if boost versin >= 1.54, find coroutine otherwise will cause link errors
   IF(NOT "${Boost_VERSION}" MATCHES "1.53(.*)")
+    SET(BOOST_LIBRARIES_TEMP ${Boost_LIBRARIES})
     FIND_PACKAGE(Boost 1.54 REQUIRED COMPONENTS coroutine)
+    SET(Boost_LIBRARIES ${BOOST_LIBRARIES_TEMP} ${Boost_LIBRARIES})
   ENDIF()
 
 ELSE(WIN32)


### PR DESCRIPTION
using boost>=1.54 with cmake on windows.

When FIND_PACKAGE(BOOST ...) is run, it overwrites the previous ${Boost_LIBRARIES} with its own required libraries

http://stackoverflow.com/questions/19720639/handling-multiple-find-package-calls-in-cmake
