### PR TITLE
filesystem::rename() can handle file from cross device

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -234,8 +234,13 @@ namespace fc {
      try {
   	    boost::filesystem::rename( boost::filesystem::path(f), boost::filesystem::path(t) ); 
      } catch ( boost::system::system_error& e ) {
-     	FC_THROW( "Rename from ${srcfile} to ${dstfile} failed because ${reason}",
-	         ("srcfile",f)("dstfile",t)("reason",e.what() ) );
+         try{
+             boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t) ); 
+             boost::filesystem::remove( boost::filesystem::path(f)); 
+         } catch ( boost::system::system_error& e ) {
+             FC_THROW( "Rename from ${srcfile} to ${dstfile} failed because ${reason}",
+                     ("srcfile",f)("dstfile",t)("reason",e.what() ) );
+         }
      } catch ( ... ) {
      	FC_THROW( "Rename from ${srcfile} to ${dstfile} failed",
 	         ("srcfile",f)("dstfile",t)("inner", fc::except_str() ) );


### PR DESCRIPTION
when I run blockchain_tests, I got message:

Unable to save wallet /tmp/e204-365d-23c3-970b/wallet.dat
    {"wallet":"/tmp/e204-365d-23c3-970b/wallet.dat"}
    th_a  wallet.cpp:478 save
unspecified
Rename from /tmp/e204-365d-23c3-970b/wallet.dat to af5a-d064-b93f-ff6e failed because boost::filesystem::rename: Invalid cross-device link: "/tmp/e204-365d-23c3-970b/wallet.dat", "af5a-d064-b93f-ff6e"
    {"srcfile":"/tmp/e204-365d-23c3-970b/wallet.dat","dstfile":"af5a-d064-b93f-ff6e","reason":"boost::filesystem::rename: Invalid cross-device link: \"/tmp/e204-365d-23c3-970b/wallet.dat\", \"af5a-d064-b93f-ff6e\""}
    th_a  filesystem.cpp:238 rename
Unable to save wallet /tmp/e204-365d-23c3-970b/wallet.dat
    {"wallet":"/tmp/e204-365d-23c3-970b/wallet.dat"}
    th_a  wallet.cpp:478 save
unable to import private key
