### PR TITLE
Fix issue #25

### DIFF
--- a/src/io/sstream.cpp
+++ b/src/io/sstream.cpp
@@ -9,13 +9,13 @@ namespace fc {
     public:
     impl( fc::string&s )
     :ss( s )
-    { ss.exceptions( std::stringstream::badbit | std::stringstream::eofbit ); }
+    { ss.exceptions( std::stringstream::badbit ); }
 
     impl( const fc::string&s )
     :ss( s )
-    { ss.exceptions( std::stringstream::badbit | std::stringstream::eofbit ); }
+    { ss.exceptions( std::stringstream::badbit ); }
 
-    impl(){ss.exceptions( std::stringstream::badbit | std::stringstream::eofbit ); }
+    impl(){ss.exceptions( std::stringstream::badbit ); }
     
     std::stringstream ss;
   };


### PR DESCRIPTION
eofbit std exception is replaced by eof_exception, checked in peek(), so no need to throw std exception when encounter EOF.

closed #25 
