### PR TITLE
Add missing synchronous call overload to json_connection

### DIFF
--- a/include/fc/rpc/json_connection.hpp
+++ b/include/fc/rpc/json_connection.hpp
@@ -108,6 +108,14 @@ namespace fc { namespace rpc  {
                                      );
 
          template<typename Result>
+         Result call( const fc::string& method,
+                               const variants& args,
+                               microseconds timeout = microseconds::maximum())
+         {
+             return async_call( method, args ).wait(timeout).as<Result>();
+         }
+
+         template<typename Result>
          Result call( const fc::string& method, 
                                const variant& a1, 
                                const variant& a2, 


### PR DESCRIPTION
All of the async_call overloads had a synchronous call wrapper except for one, so I added a wrapper for that one as well.
