### PR TITLE
Compare HTTP headers case-insensitively

### DIFF
--- a/src/network/http/http_connection.cpp
+++ b/src/network/http/http_connection.cpp
@@ -172,7 +172,7 @@ http::request    connection::read_request()const {
 
 fc::string request::get_header( const fc::string& key )const {
   for( auto itr = headers.begin(); itr != headers.end(); ++itr ) {
-    if( itr->key == key ) { return itr->val; } 
+    if( boost::iequals(itr->key, key) ) { return itr->val; } 
   }
   return fc::string();
 }


### PR DESCRIPTION
Without this change it's impossible to call the HTTP RPC API from Node.js.

See also https://groups.google.com/d/msg/nodejs/XIU55IYtfJo/feUp9Fz7p14J
