### PR TITLE
Json parser mods

### DIFF
--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -22,28 +22,33 @@ namespace fc
             relaxed_parser        = 2,
             legacy_parser_with_string_doubles = 3
          };
+         enum output_formatting
+         {
+            stringify_large_ints_and_doubles = 0,
+            legacy_generator = 1
+         };
 
-         static ostream& to_stream( ostream& out, const fc::string& );
-         static ostream& to_stream( ostream& out, const variant& v );
-         static ostream& to_stream( ostream& out, const variants& v );
-         static ostream& to_stream( ostream& out, const variant_object& v );
+         static ostream& to_stream( ostream& out, const fc::string&);
+         static ostream& to_stream( ostream& out, const variant& v, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const variants& v, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const variant_object& v, output_formatting format = stringify_large_ints_and_doubles );
 
          static variant  from_stream( buffered_istream& in, parse_type ptype = legacy_parser );
 
          static variant  from_string( const string& utf8_str, parse_type ptype = legacy_parser );
          static variants variants_from_string( const string& utf8_str, parse_type ptype = legacy_parser );
-         static string   to_string( const variant& v );
-         static string   to_pretty_string( const variant& v );
+         static string   to_string( const variant& v, output_formatting format = stringify_large_ints_and_doubles );
+         static string   to_pretty_string( const variant& v, output_formatting format = stringify_large_ints_and_doubles );
 
          static bool     is_valid( const std::string& json_str, parse_type ptype = legacy_parser );
 
          template<typename T>
-         static void     save_to_file( const T& v, const fc::path& fi, bool pretty = true )
+         static void     save_to_file( const T& v, const fc::path& fi, bool pretty = true, output_formatting format = stringify_large_ints_and_doubles )
          {
-            save_to_file( variant(v), fi, pretty );
+            save_to_file( variant(v), fi, pretty, format );
          }
 
-         static void     save_to_file( const variant& v, const fc::path& fi, bool pretty = true );
+         static void     save_to_file( const variant& v, const fc::path& fi, bool pretty = true, output_formatting format = stringify_large_ints_and_doubles );
          static variant  from_file( const fc::path& p, parse_type ptype = legacy_parser );
 
          template<typename T>
@@ -53,19 +58,19 @@ namespace fc
          }
 
          template<typename T>
-         static string   to_string( const T& v ) 
+         static string   to_string( const T& v, output_formatting format = stringify_large_ints_and_doubles ) 
          {
-            return to_string( variant(v) );
+            return to_string( variant(v), format );
          }
 
          template<typename T>
-         static string   to_pretty_string( const T& v ) 
+         static string   to_pretty_string( const T& v, output_formatting format = stringify_large_ints_and_doubles ) 
          {
-            return to_pretty_string( variant(v) );
+            return to_pretty_string( variant(v), format );
          }
 
          template<typename T>
-         static void save_to_file( const T& v, const std::string& p, bool pretty = true ) 
+         static void save_to_file( const T& v, const std::string& p, bool pretty = true, output_formatting format = stringify_large_ints_and_doubles ) 
          {
             save_to_file( variant(v), fc::path(p), pretty );
          } 

--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -19,7 +19,8 @@ namespace fc
          {
             legacy_parser         = 0,
             strict_parser         = 1,
-            relaxed_parser        = 2
+            relaxed_parser        = 2,
+            legacy_parser_with_string_doubles = 3
          };
 
          static ostream& to_stream( ostream& out, const fc::string& );

--- a/include/fc/io/json_relaxed.hpp
+++ b/include/fc/io/json_relaxed.hpp
@@ -581,7 +581,7 @@ namespace fc { namespace json_relaxed
                continue;
             }
             if( skip_white_space(in) ) continue;
-            string key = stringFromStream<T, strict>( in );
+            string key = json_relaxed::stringFromStream<T, strict>( in );
             skip_white_space(in);
             if( in.peek() != ':' )
             {
@@ -589,7 +589,7 @@ namespace fc { namespace json_relaxed
                                         ("key", key) );
             }
             in.get();
-            auto val = variant_from_stream<T, strict>( in );
+            auto val = json_relaxed::variant_from_stream<T, strict>( in );
 
             obj(std::move(key),std::move(val));
             skip_white_space(in);
@@ -630,7 +630,7 @@ namespace fc { namespace json_relaxed
               continue;
            }
            if( skip_white_space(in) ) continue;
-           ar.push_back( variant_from_stream<T, strict>(in) );
+           ar.push_back( json_relaxed::variant_from_stream<T, strict>(in) );
            skip_white_space(in);
         }
         if( in.peek() != ']' )
@@ -647,7 +647,7 @@ namespace fc { namespace json_relaxed
    variant numberFromStream( T& in )
    { try {
        fc::string token = tokenFromStream(in);
-       variant result = parseNumberOrStr<strict>( token );
+       variant result = json_relaxed::parseNumberOrStr<strict>( token );
        if( strict && !(result.is_int64() || result.is_uint64() || result.is_double()) )
            FC_THROW_EXCEPTION( parse_error_exception, "expected: number" );
        return result;
@@ -700,11 +700,11 @@ namespace fc { namespace json_relaxed
               in.get();
               continue;
             case '"':
-              return stringFromStream<T, strict>( in );
+              return json_relaxed::stringFromStream<T, strict>( in );
             case '{':
-              return objectFromStream<T, strict>( in );
+              return json_relaxed::objectFromStream<T, strict>( in );
             case '[':
-              return arrayFromStream<T, strict>( in );
+              return json_relaxed::arrayFromStream<T, strict>( in );
             case '-':
             case '+':
             case '.':
@@ -718,7 +718,7 @@ namespace fc { namespace json_relaxed
             case '7':
             case '8':
             case '9':
-              return numberFromStream<T, strict>( in );
+              return json_relaxed::numberFromStream<T, strict>( in );
             // null, true, false, or 'warning' / string
             case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g': case 'h':
             case 'i': case 'j': case 'k': case 'l': case 'm': case 'n': case 'o': case 'p':
@@ -729,7 +729,7 @@ namespace fc { namespace json_relaxed
             case 'Q': case 'R': case 'S': case 'T': case 'U': case 'V': case 'W': case 'X':
             case 'Y': case 'Z':
             case '_':                               case '/':
-              return wordFromStream<T, strict>( in );
+              return json_relaxed::wordFromStream<T, strict>( in );
             case 0x04: // ^D end of transmission
             case EOF:
               FC_THROW_EXCEPTION( eof_exception, "unexpected end of file" );

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <iomanip>
 #include <locale>
+#include <limits>
 
 /**
  *  Implemented with std::string for now.
@@ -127,11 +128,12 @@ namespace fc  {
     FC_RETHROW_EXCEPTIONS( warn, "${i} => double", ("i",i) )
   }
 
-  fc::string to_string( double d)
+  fc::string to_string(double d)
   {
-     std::stringstream ss; 
-     ss << std::setprecision(12) << std::fixed << d;
-    return ss.str(); //boost::lexical_cast<std::string>(d);
+    // +2 is required to ensure that the double is rounded correctly when read back in.  http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+    std::stringstream ss;
+    ss << std::setprecision(std::numeric_limits<double>::digits10 + 2) << std::fixed << d;
+    return ss.str();
   }
 
   fc::string to_string( uint64_t d)


### PR DESCRIPTION
This doesn't change the default behavior of any existing code, but introduces two new options reading & writing json.  On the input side, it adds a new mode to read all un-quoted floating point numbers in to strings instead of reading them as doubles (to avoid potential rounding errors).  On the output side, it adds a mode that restores the original behavior of writing doubles out as numbers instead of strings (some json parsers are picky about this)