### PR TITLE
Support fcontext API in Boost 1.61

### DIFF
--- a/src/thread/context.hpp
+++ b/src/thread/context.hpp
@@ -48,7 +48,11 @@ namespace fc {
 #endif
 
 
+#if BOOST_VERSION >= 106100
+    context( void (*sf)(bc::detail::transfer_t), stack_allocator& alloc, fc::thread* t )
+#else
     context( void (*sf)(intptr_t), stack_allocator& alloc, fc::thread* t )
+#endif
     : caller_context(0),
       stack_alloc(&alloc),
       next_blocked(0), 
@@ -63,7 +67,11 @@ namespace fc {
       cur_task(0),
       context_posted_num(0)
     {
-#if BOOST_VERSION >= 105600
+#if BOOST_VERSION >= 106100
+     size_t stack_size = FC_CONTEXT_STACK_SIZE;
+     alloc.allocate(stack_ctx, stack_size);
+     my_context = bc::detail::make_fcontext( stack_ctx.sp, stack_ctx.size, sf);
+#elif BOOST_VERSION >= 105600
      size_t stack_size = FC_CONTEXT_STACK_SIZE;
      alloc.allocate(stack_ctx, stack_size);
      my_context = bc::make_fcontext( stack_ctx.sp, stack_ctx.size, sf); 
@@ -209,7 +217,10 @@ namespace fc {
 
 
 
-#if BOOST_VERSION >= 105300 && BOOST_VERSION < 105600
+
+#if BOOST_VERSION >= 106100
+    bc::detail::fcontext_t       my_context;
+#elif BOOST_VERSION >= 105300 && BOOST_VERSION < 105600
     bc::fcontext_t*              my_context;
 #else
     bc::fcontext_t               my_context;

--- a/src/thread/thread_d.hpp
+++ b/src/thread/thread_d.hpp
@@ -397,7 +397,9 @@ namespace fc {
                 }
                 // slog( "jump to %p from %p", next, prev );
                 // fc_dlog( logger::get("fc_context"), "from ${from} to ${to}", ( "from", int64_t(prev) )( "to", int64_t(next) ) ); 
-#if BOOST_VERSION >= 105600
+#if BOOST_VERSION >= 106100
+                prev->my_context = bc::detail::jump_fcontext( next->my_context, 0 ).fctx;
+#elif BOOST_VERSION >= 105600
                 bc::jump_fcontext( &prev->my_context, next->my_context, 0 );
 #elif BOOST_VERSION >= 105300
                 bc::jump_fcontext( prev->my_context, next->my_context, 0 );
@@ -439,7 +441,9 @@ namespace fc {
 
                 // slog( "jump to %p from %p", next, prev );
                 // fc_dlog( logger::get("fc_context"), "from ${from} to ${to}", ( "from", int64_t(prev) )( "to", int64_t(next) ) );
-#if BOOST_VERSION >= 105600
+#if BOOST_VERSION >= 106100
+                prev->my_context = bc::detail::jump_fcontext( next->my_context, this ).fctx;
+#elif BOOST_VERSION >= 105600
                 bc::jump_fcontext( &prev->my_context, next->my_context, (intptr_t)this );
 #elif BOOST_VERSION >= 105300
                 bc::jump_fcontext( prev->my_context, next->my_context, (intptr_t)this );
@@ -467,9 +471,15 @@ namespace fc {
               return true;
            }
 
+#if BOOST_VERSION >= 106100
+           static void start_process_tasks( bc::detail::transfer_t my )
+           {
+              thread_d* self = (thread_d*)my.data;
+#else
            static void start_process_tasks( intptr_t my ) 
            {
               thread_d* self = (thread_d*)my;
+#endif
               try 
               {
                 self->process_tasks();


### PR DESCRIPTION
In Boost 1.61, the API for fcontext_t was changed. I made some changes here to get fc to compile on my machine with Boost 1.61. It is a little hacky but it compiles. However, I have not been able to test it properly. I am trying to build graphene/bitshares-2 but that build fails later in the process. As for fc, running `all_tests` shows the following. I have not compared this with what would happen on my machine with Boost < 1.61:

```
$ ./all_tests
Running 35 test cases...
10 assert_exception: Assert Exception
out_len <= out.size():
    {}
    th_a  smaz.cpp:212 smaz_compress
/home/cel/src/bitshares-2/libraries/fc/tests/crypto/rand_test.cpp(24): error: in "fc_crypto/rand_test": check rc > E - sigma && rc < E + sigma has failed
unknown location(0): fatal error: in "fc_network/ntp_test": memory access violation at address: 0x00000000: no mapping at fault address
/home/cel/src/bitshares-2/libraries/fc/tests/network/ntp_test.cpp(9): last checkpoint: "ntp_test" entry.

*** 2 failures are detected in the test module "AllTests"
```
